### PR TITLE
where.adoc: remove the 13.0 section

### DIFF
--- a/website/content/en/where.adoc
+++ b/website/content/en/where.adoc
@@ -83,59 +83,6 @@ a|
 
 |===
 
-[[download-rel130]]
-== FreeBSD {rel130-current}-RELEASE
-[.tblbasic]
-[.tblDownload]
-[width="100%",cols="25%,25%,25%,25%",options="header",]
-|===
-|Installer Images |Virtual Machine Images |SD Card Images |Documentation
-a|
-* link:{url-rel}/amd64/amd64/ISO-IMAGES/{rel130-current}/[amd64]
-* link:{url-rel}/i386/i386/ISO-IMAGES/{rel130-current}/[i386]
-* link:{url-rel}/powerpc/powerpc/ISO-IMAGES/{rel130-current}/[powerpc]
-* link:{url-rel}/powerpc/powerpc64/ISO-IMAGES/{rel130-current}/[powerpc64]
-* link:{url-rel}/powerpc/powerpc64le/ISO-IMAGES/{rel130-current}/[powerpc64le]
-* link:{url-rel}/powerpc/powerpcspe/ISO-IMAGES/{rel130-current}/[powerpcspe]
-* link:{url-rel}/arm/armv6/ISO-IMAGES/{rel130-current}/[armv6]
-* link:{url-rel}/arm/armv7/ISO-IMAGES/{rel130-current}/[armv7]
-* link:{url-rel}/arm64/aarch64/ISO-IMAGES/{rel130-current}/[aarch64]
-* link:{url-rel}/riscv/riscv64/ISO-IMAGES/{rel130-current}/[riscv64]
-
-a|
-* link:{url-rel}/VM-IMAGES/README.txt[README]
-* link:{url-rel}/VM-IMAGES/{rel130-current}-RELEASE/amd64/Latest/[amd64]
-* link:{url-rel}/VM-IMAGES/{rel130-current}-RELEASE/i386/Latest/[i386]
-* link:{url-rel}/VM-IMAGES/{rel130-current}-RELEASE/aarch64/Latest/[aarch64]
-* link:{url-rel}/VM-IMAGES/{rel130-current}-RELEASE/riscv64/Latest/[riscv64]
-
-a|
-* aarch64
-* {blank}
-** link:{url-rel}/arm64/aarch64/ISO-IMAGES/{rel130-current}/[PINE64]
-** link:{url-rel}/arm64/aarch64/ISO-IMAGES/{rel130-current}/[PINE64-LTS]
-** link:{url-rel}/arm64/aarch64/ISO-IMAGES/{rel130-current}/[ROCK64]
-** link:{url-rel}/arm64/aarch64/ISO-IMAGES/{rel130-current}/[ROCKPRO64]
-** link:{url-rel}/arm64/aarch64/ISO-IMAGES/{rel130-current}/[RPI] (3/4)
-* armv6/armv7
-* {blank}
-** link:{url-rel}/arm/armv7/ISO-IMAGES/{rel130-current}/[GENERICSD]
-** link:{url-rel}/arm/armv6/ISO-IMAGES/{rel130-current}/[RPI-B]
-* riscv64
-* {blank}
-** link:{url-rel}/riscv/riscv64/ISO-IMAGES/{rel130-current}/[GENERICSD]
-
-a|
-* link:../releases/#current[Released]: {rel130-current-date}
-* link:{u-rel130-notes}[Release Notes]
-* link:{u-rel130-readme}[Readme]
-* link:{u-rel130-hardware}[Hardware Compatibility List]
-* link:{u-rel130-installation}[Installation Instructions]
-* link:{u-rel130-errata}[Errata]
-* link:{u-rel130-signatures}[Signed Checksums]
-
-|===
-
 [[download-rel123]]
 == FreeBSD {rel123-current}-RELEASE
 


### PR DESCRIPTION
There's not yet movement on <https://reviews.freebsd.org/D36523>, and the presence of 13.0 is a source of confusion (e.g. <https://old.reddit.com/r/freebsd/comments/xfyaui/-/>. 

Let's remove the 13.0 section i.e. <https://www.freebsd.org/where/#download-rel130> without delay, then I'll produce a new diff for D36523.